### PR TITLE
fixed jvm version for both java and kotlin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,15 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
We found the issue that caused a JVM compatibility problem between Java and Kotlin, which prevented us from building the Android app. This PR fixed the issue, but I'm not sure why.


https://github.com/user-attachments/assets/2e76bfab-cc88-45e5-9160-5acc64a54cac



